### PR TITLE
fix: flickering when cooldowns occur.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import * as utility from './lib/utility';
-import { Overlay } from './types';
+import { CombatStyle, Overlay } from './types';
 
 // General Purpose
 import { findBuffsBar, findDebuffsBar, readBuffs } from './lib/readBuffs';
@@ -32,13 +32,7 @@ import { A1Sauce } from './a1sauce';
 import { getSetting, updateSetting } from './a1sauce/Settings/Storage';
 import { getById } from './a1sauce/Utils/getById';
 import { renderSettings } from './lib/settings';
-import {
-    appName,
-    majorVersion,
-    minorVersion,
-    patchVersion,
-    versionUrl,
-} from './data/constants';
+import { appName, majorVersion, minorVersion, patchVersion, versionUrl } from './data/constants';
 import { Patches } from './a1sauce/Patches/patchNotes';
 import { notes } from './patchnotes';
 import { startVersionChecking } from './a1sauce/Patches/serverCheck';
@@ -76,35 +70,36 @@ const gauges: Overlay = {
 
 async function renderOverlays() {
     await readEnemy(gauges);
-    if (gauges.isInCombat || getSetting('updatingOverlayPosition')) {
-        await readBuffs(gauges);
-        switch (gauges.combatStyle) {
-            case 4:
-                await livingDeathOverlay(gauges);
-                await conjureOverlay(gauges);
-                await soulsOverlay(gauges);
-                await necrosisOverlay(gauges);
-                await incantationsOverlay(gauges);
-                await bloatOverlay(gauges);
-                break;
-            case 3:
-                await sunshineOverlay(gauges);
-                await spellsOverlay(gauges);
-                await fsoaOverlay(gauges);
-                await tsunamiOverlay(gauges);
-                await odeToDeceitOverlay(gauges);
-                break;
-            case 2:
-                await deathsSwiftnessOverlay(gauges);
-                await crystalRainOverlay(gauges);
-                await peOverlay(gauges);
-                await rangedSplitSoulOverlay(gauges);
-                break;
-            case 1:
-                break;
-        }
-    } else {
-        utility.clearTextOverlays();
+
+    if (!gauges.isInCombat && !getSetting('updatingOverlayPosition')) {
+        return utility.clearTextOverlays();
+    }
+
+    await readBuffs(gauges);
+    switch (gauges.combatStyle) {
+        case CombatStyle.necro:
+            await livingDeathOverlay(gauges);
+            await conjureOverlay(gauges);
+            await soulsOverlay(gauges);
+            await necrosisOverlay(gauges);
+            await incantationsOverlay(gauges);
+            await bloatOverlay(gauges);
+            break;
+        case CombatStyle.mage:
+            await sunshineOverlay(gauges);
+            await spellsOverlay(gauges);
+            await fsoaOverlay(gauges);
+            await tsunamiOverlay(gauges);
+            await odeToDeceitOverlay(gauges);
+            break;
+        case CombatStyle.ranged:
+            await deathsSwiftnessOverlay(gauges);
+            await crystalRainOverlay(gauges);
+            await peOverlay(gauges);
+            await rangedSplitSoulOverlay(gauges);
+            break;
+        case CombatStyle.melee:
+            break;
     }
 }
 
@@ -185,7 +180,7 @@ export function resetPositionsAndFindBuffAndDebuffBars() {
 }
 
 export function beginRendering() {
-    setInterval(() => renderOverlays(), 20);
+    setInterval(() => renderOverlays(), 80);
 }
 
 function calibrationWarning(): void {
@@ -507,7 +502,7 @@ function setNecromancyGaugeData(gauges: Overlay) {
     }
 
     if (getSetting('defaultCombatStyle') !== undefined) {
-        let input = <HTMLSelectElement>(
+        const input = <HTMLSelectElement>(
             document.getElementById('defaultCombatStyle')
         );
         input.value = getSetting('defaultCombatStyle');
@@ -519,7 +514,7 @@ function setNecromancyGaugeData(gauges: Overlay) {
 // TODO: and recover it instead of setting each property individually from a different setting
 // TODO: Just need to figure out why my earlier attempt with setGaugeData() wasn't saving values properly
 function getGaugeData(gauges: Overlay) {
-    let gaugeData = getSetting('gaugedata');
+    const gaugeData = getSetting('gaugedata');
     if (gaugeData !== undefined) {
         gauges = gaugeData;
         return JSON.parse(gaugeData);

--- a/src/lib/readBuffs.ts
+++ b/src/lib/readBuffs.ts
@@ -205,177 +205,179 @@ retryOperation(findDebuffsBar, 3, 10000)
     });
 
 export async function readBuffs(gauges: Overlay) {
-    if (buffReader.pos !== undefined) {
+    if (!buffReader.pos) {
+        return;
+    }
+
+    updateBuffData(
+        buffReader,
+        gauges,
+        buffsImages.deathsSwiftness,
+        300,
+        updateDeathsSwiftness,
+        false,
+    );
+    updateBuffData(
+        buffReader,
+        gauges,
+        buffsImages.greaterDeathsSwiftness,
+        300,
+        updateDeathsSwiftness,
+        true,
+    );
+    updateBuffData(
+        buffReader,
+        gauges,
+        buffsImages.sunshine,
+        300,
+        updateSunshine,
+        false,
+    );
+    updateBuffData(
+        buffReader,
+        gauges,
+        buffsImages.greaterSunshine,
+        100,
+        updateSunshine,
+        true,
+    );
+    if (gauges.necromancy.livingDeath.isActiveOverlay) {
         updateBuffData(
             buffReader,
             gauges,
-            buffsImages.deathsSwiftness,
-            300,
-            updateDeathsSwiftness,
+            buffsImages.living_death,
+            400,
+            updateLivingDeath,
             false,
         );
-        updateBuffData(
-            buffReader,
-            gauges,
-            buffsImages.greaterDeathsSwiftness,
-            300,
-            updateDeathsSwiftness,
-            true,
-        );
-        updateBuffData(
-            buffReader,
-            gauges,
-            buffsImages.sunshine,
-            300,
-            updateSunshine,
-            false,
-        );
-        updateBuffData(
-            buffReader,
-            gauges,
-            buffsImages.greaterSunshine,
-            100,
-            updateSunshine,
-            true,
-        );
-        if (gauges.necromancy.livingDeath.isActiveOverlay) {
+    }
+
+    switch (gauges.combatStyle) {
+        case CombatStyle.necro:
             updateBuffData(
                 buffReader,
                 gauges,
-                buffsImages.living_death,
-                400,
-                updateLivingDeath,
+                buffsImages.soul,
+                200,
+                updateSoulCount,
                 false,
             );
-        }
+            updateBuffData(
+                buffReader,
+                gauges,
+                buffsImages.necrosis,
+                200,
+                updateNecrosisCount,
+                false,
+            );
+            updateConjures(gauges);
 
-        switch (gauges.combatStyle) {
-            case 4:
-                updateBuffData(
-                    buffReader,
-                    gauges,
-                    buffsImages.soul,
-                    200,
-                    updateSoulCount,
-                    false,
-                );
-                updateBuffData(
-                    buffReader,
-                    gauges,
-                    buffsImages.necrosis,
-                    200,
-                    updateNecrosisCount,
-                    false,
-                );
-                updateConjures(gauges);
+            updateBuffData(
+                buffReader,
+                gauges,
+                buffsImages.darkness,
+                300,
+                updateDarkness,
+                false,
+            );
 
+            if (!disableThreadsCheck) {
                 updateBuffData(
                     buffReader,
                     gauges,
-                    buffsImages.darkness,
+                    buffsImages.threads,
                     300,
-                    updateDarkness,
+                    updateThreads,
                     false,
                 );
-
-                if (!disableThreadsCheck) {
-                    updateBuffData(
-                        buffReader,
-                        gauges,
-                        buffsImages.threads,
-                        300,
-                        updateThreads,
-                        false,
-                    );
-                }
-                if (!disableSplitCheck) {
-                    updateBuffData(
-                        buffReader,
-                        gauges,
-                        buffsImages.split_soul,
-                        350,
-                        updateSplitSoul,
-                        false,
-                    );
-                }
-                break;
-            case 3:
+            }
+            if (!disableSplitCheck) {
                 updateBuffData(
                     buffReader,
                     gauges,
-                    buffsImages.instability,
-                    60,
-                    updateFsoa,
+                    buffsImages.split_soul,
+                    350,
+                    updateSplitSoul,
                     false,
                 );
-                updateBuffData(
-                    buffReader,
-                    gauges,
-                    buffsImages.tsunami,
-                    200,
-                    updateTsunami,
-                    false,
-                );
-                updateStackData(
-                    gauges,
-                    buffsImages.bloodTithe,
-                    30,
-                    updateBloodTithe,
-                );
-                updateStackData(
-                    gauges,
-                    buffsImages.glacialEmbrace,
-                    30,
-                    updateGlacialEmbrace,
-                );
-                updateBuffData(
-                    debuffReader,
-                    gauges,
-                    buffsImages.odeToDeceit,
-                    9,
-                    updateOdeToDeceit,
-                    false,
-                );
-                break;
-            case 2:
-                updateBuffData(
-                    debuffReader,
-                    gauges,
-                    buffsImages.crystalRain,
-                    60,
-                    updateCrystalRain,
-                    false,
-                );
-                findAmmo(gauges, buffReader.read());
-                updateSimpleStackData(
-                    gauges,
-                    buffsImages.perfectEquilibrium,
-                    300,
-                    updatePeCount,
-                );
-                updateBuffData(
-                    buffReader,
-                    gauges,
-                    buffsImages.balanaceByForce,
-                    20,
-                    updateBalanceByForce,
-                    false,
-                );
-                updateBuffData(
-                    buffReader,
-                    gauges,
-                    buffsImages.rangedSplitSoul,
-                    300,
-                    updateRangedSplitSoul,
-                    false,
-                );
-                break;
-            case 1:
-                break;
-        }
-
-        return buffReader;
+            }
+            break;
+        case CombatStyle.mage:
+            updateBuffData(
+                buffReader,
+                gauges,
+                buffsImages.instability,
+                60,
+                updateFsoa,
+                false,
+            );
+            updateBuffData(
+                buffReader,
+                gauges,
+                buffsImages.tsunami,
+                200,
+                updateTsunami,
+                false,
+            );
+            updateStackData(
+                gauges,
+                buffsImages.bloodTithe,
+                30,
+                updateBloodTithe,
+            );
+            updateStackData(
+                gauges,
+                buffsImages.glacialEmbrace,
+                30,
+                updateGlacialEmbrace,
+            );
+            updateBuffData(
+                debuffReader,
+                gauges,
+                buffsImages.odeToDeceit,
+                9,
+                updateOdeToDeceit,
+                false,
+            );
+            break;
+        case CombatStyle.ranged:
+            updateBuffData(
+                debuffReader,
+                gauges,
+                buffsImages.crystalRain,
+                60,
+                updateCrystalRain,
+                false,
+            );
+            findAmmo(gauges, buffReader.read());
+            updateSimpleStackData(
+                gauges,
+                buffsImages.perfectEquilibrium,
+                300,
+                updatePeCount,
+            );
+            updateBuffData(
+                buffReader,
+                gauges,
+                buffsImages.balanaceByForce,
+                20,
+                updateBalanceByForce,
+                false,
+            );
+            updateBuffData(
+                buffReader,
+                gauges,
+                buffsImages.rangedSplitSoul,
+                300,
+                updateRangedSplitSoul,
+                false,
+            );
+            break;
+        case CombatStyle.melee:
+            break;
     }
+
+    return buffReader;
 }
 
 async function updateBuffData(

--- a/src/lib/utility.ts
+++ b/src/lib/utility.ts
@@ -235,7 +235,7 @@ export function roundedToFixed(input: number, digits: number): string {
 }
 
 export function handleResizingImages(
-    images: { [k in string]: ImageData | unknown },
+    images: Record<string, ImageData | unknown>,
     scaleFactor: number,
 ) {
     for (const key of Object.keys(images)) {

--- a/src/types/magicGauge.ts
+++ b/src/types/magicGauge.ts
@@ -1,5 +1,13 @@
 import { Position, Ability, StackingPlayerBuff } from './common';
 
+export enum ActiveSpells {
+    Exsanguinate = 1,
+    Incite_Fear = 2,
+    Ice_Barrage = 3,
+}
+
+export type ActiveSpellNames = keyof typeof ActiveSpells;
+
 export type Spells = {
     isActiveOverlay: boolean;
     activeSpell: number;


### PR DESCRIPTION
This PR fixes issue #49 by keeping track of which ability is currently on CD with a bool map. It prevents future invokations of the function from doing anything extra with the overlays.

This PR also does some "cleanup" work. Mostly removing indentation and adding early returns.
Also..
- Updating switchcases that used numbers instead of the combat style enum
- Active spells using an enum to reduce if checking